### PR TITLE
develop

### DIFF
--- a/libs/core/CHANGELOG.md
+++ b/libs/core/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.2.1 (2024-08-08)
+
+
+### 🩹 Fixes
+
+- **core:** add `publishConfig` to `package.json` ([954eb70](https://github.com/marcolongol/nx-extensions/commit/954eb70))
+
+- **deps:** update nrwl monorepo to v19.5.7 ([7c04f5e](https://github.com/marcolongol/nx-extensions/commit/7c04f5e))
+
+
+### ❤️  Thank You
+
+- Lucas Marcolongo @marcolongol
+
 ## 0.2.0 (2024-08-07)
 
 

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-extensions/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/helm/CHANGELOG.md
+++ b/packages/helm/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.6.1 (2024-08-08)
+
+
+### 🩹 Fixes
+
+- **deps:** update nrwl monorepo to v19.5.7 ([7c04f5e](https://github.com/marcolongol/nx-extensions/commit/7c04f5e))
+
+- **helm:** move `@nx/devkit` to `peerDependencies` ([65a06b4](https://github.com/marcolongol/nx-extensions/commit/65a06b4))
+
+- **helm:** use `{workspaceRoot}/dist/charts/{projectRoot}` as default output folder ([0a41aef](https://github.com/marcolongol/nx-extensions/commit/0a41aef))
+
+- **helm:** fix `format` option description and prompt ([8120f6d](https://github.com/marcolongol/nx-extensions/commit/8120f6d))
+
+
+### 🧱 Updated Dependencies
+
+- Updated core to 0.2.1
+
+
+### ❤️  Thank You
+
+- Lucas Marcolongo @marcolongol
+
 ## 0.6.0 (2024-08-07)
 
 

--- a/packages/helm/package.json
+++ b/packages/helm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-extensions/helm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -11,7 +11,7 @@
     "directory": "packages/helm"
   },
   "dependencies": {
-    "@nx-extensions/core": "0.2.0",
+    "@nx-extensions/core": "0.2.1",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/helm/package.json
+++ b/packages/helm/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "@nx-extensions/core": "0.2.0",
-    "@nx/devkit": "19.5.7",
     "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@nx/devkit": "19.5.7"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/helm/src/generators/chart/generator.spec.ts
+++ b/packages/helm/src/generators/chart/generator.spec.ts
@@ -76,7 +76,7 @@ describe('chart generator', () => {
     ]);
     expect(projectConfig.targets['helm'].options).toEqual({
       chartFolder: `${projectConfig.root}/${options.chartFolder}`,
-      outputFolder: '{workspaceRoot}/charts/{projectRoot}',
+      outputFolder: '{workspaceRoot}/dist/charts/{projectRoot}',
       push: false,
       remote: 'oci://localhost:5000/helm-charts',
     });

--- a/packages/helm/src/generators/chart/generator.ts
+++ b/packages/helm/src/generators/chart/generator.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   formatFiles,
   generateFiles,
+  logger,
   readProjectConfiguration,
   Tree,
   updateProjectConfiguration,
@@ -50,6 +51,11 @@ export async function chartGenerator(
   if (options.format) {
     await formatFiles(tree);
   }
+
+  // TODO: can we do this programmatically?
+  logger.warn(
+    `Add ${project.root}/${options.chartFolder} to .prettierignore to avoid Helm chart syntax errors.`,
+  );
 }
 
 export default chartGenerator;

--- a/packages/helm/src/generators/chart/generator.ts
+++ b/packages/helm/src/generators/chart/generator.ts
@@ -31,7 +31,7 @@ export async function chartGenerator(
         outputs: ['{options.outputFolder}'],
         options: {
           chartFolder: `${project.root}/${options.chartFolder}`,
-          outputFolder: '{workspaceRoot}/charts/{projectRoot}',
+          outputFolder: '{workspaceRoot}/dist/charts/{projectRoot}',
           push: false,
           remote: 'oci://localhost:5000/helm-charts',
         },

--- a/packages/helm/src/generators/chart/schema.d.ts
+++ b/packages/helm/src/generators/chart/schema.d.ts
@@ -11,7 +11,7 @@ export interface ChartGeneratorSchema {
   project: string;
   /** Folder to store the chart */
   chartFolder?: string;
-  /** Skip formatting the chart */
+  /** Format the generated chart */
   format?: boolean;
   [k: string]: unknown;
 }

--- a/packages/helm/src/generators/chart/schema.json
+++ b/packages/helm/src/generators/chart/schema.json
@@ -34,13 +34,13 @@
     },
     "format": {
       "type": "boolean",
-      "description": "Skip formatting the chart",
+      "description": "Format the generated chart",
       "$default": {
         "$source": "argv",
         "index": 3
       },
       "default": false,
-      "x-prompt": "Skip formatting the generated chart?"
+      "x-prompt": "Format the generated chart? Warning: prettier will display errors due to the template syntax: https://github.com/prettier/prettier/issues/6517"
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
- **fix(helm): move `@nx/devkit` to `peerDependencies`**
- **fix(helm): use `{workspaceRoot}/dist/charts/{projectRoot}` as default output folder**
- **fix(helm): fix `format` option description and prompt**
- **chore(helm): add warning message asking user to manually add chart folder to workspace `.prettierignore`**
